### PR TITLE
add swipl version 7 prerequisite check and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ infrastructure to improve on that is already in place: sources and
 queries are parsed and analysed for predicates they implement and
 require.
 
+## Prerequisites
+
+You will need to install **SWI Prolog version 7 or greater** for this to
+work.  To check, run this:
+
+    % swipl --version
+
 ## Run locally
 
     % swipl proxy.pl

--- a/proxy.pl
+++ b/proxy.pl
@@ -10,6 +10,14 @@
 :- use_module(library(http/http_server_files)).
 :- use_module(library(http/http_open)).
 
+:- current_prolog_flag(version, V), 
+    V >= 70200; 
+    format('You need at least SWI-Prolog version 7.2.0 to run this -- hit <enter> to halt.~n', []), 
+    % pause here so windows users will see the message before the
+    % console window closes 
+    get0(_), 
+    halt(1).
+
 /** <module> Learn Prolog Now proxy
 
 This module implements a simple proxy that rewrites LPN to link to SWISH


### PR DESCRIPTION
Spent a morning troubleshooting this, including bugging people in ##prolog.  The fact that we'd need to upgrade to version 7 is not obvious to someone new at prolog, which is by definition the same people who would be interested in running LPN locally on, for example, their laptop.  (Problem in my case was compounded by the fact that the Ubuntu 14.04 long term support version of prolog is still 6.X, so I needed to add the ppa.)

When using 6.X, the code still appears (to a new user) to run, and the home page works, but shows server error messages when attempting to open any chapter.  The only other symptom is syntax errors in convert.pl during compile, which alone aren't enough of a clue that an upgrade to swipl itself will fix them.

(Later:)  Also added a current_prolog_flag version check in proxy.pl in collaboration with folks in ##prolog -- your option whether to include that code instead of, or in addition to, the README change.  Anne and I spent some time working out whether to just halt/1 or do the get0/1 first -- comments about that are in the code.

I apologize for both of these winding up in the same PR, and both in master. In the future, I'll make sure to work on a separate branch for each change.
